### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,26 +6,26 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DCCStepper                     KEYWORD1
+DCCStepper	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-DCCStepper                      KEYWORD2
-loop                            KEYWORD2
-setSpeed                        KEYWORD2
-setActive                       KEYWORD2
-setRPM                          KEYWORD2
-setMode                         KEYWORD2
-setMaxStepsLSB			KEYWORD2
-setMaxStepsMSB			KEYWORD2
-setCurrentPosition		KEYWORD2
+DCCStepper	KEYWORD2
+loop	KEYWORD2
+setSpeed	KEYWORD2
+setActive	KEYWORD2
+setRPM	KEYWORD2
+setMode	KEYWORD2
+setMaxStepsLSB	KEYWORD2
+setMaxStepsMSB	KEYWORD2
+setCurrentPosition	KEYWORD2
 
 
 #######################################
 # Constats (LITERAL1)
 #######################################
-STEPPER_MODE_CONT		LITERAL1
+STEPPER_MODE_CONT	LITERAL1
 STEPPER_MODE_CONSTRAINED	LITERAL1
-STEPPER_MODE_REVERSE		LITERAL1
+STEPPER_MODE_REVERSE	LITERAL1
 STEPPER_MODE_AUTO_REVERSE	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords